### PR TITLE
Fix mobile image styling issue

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -10,7 +10,7 @@ figure {
     padding: 5px;
     display: flex;
     flex-flow: column;
-    width: fit-content;
+    align-items: center;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
`width: fit-content` was probably wrong this whole time, but only just began to show issues on mobile where the images would match the size of the caption. Hard to reproduce on desktop (even when using chrome tools to emulate) so hopefully this fixes it.